### PR TITLE
Copy tags from `labels` in transmission, allow overriding default 'transmission' label

### DIFF
--- a/rfr.pl
+++ b/rfr.pl
@@ -660,6 +660,11 @@ sub t2r {
 		next;
 	  }
 
+	  my @tags = @{$tr_res->{'labels'}};
+	  my $transmission_tag = $ENV{'TRANSMISSION_TAG'} // 'transmission';
+	  if ( length( $transmission_tag ) ) {
+		push( @tags, $transmission_tag );
+	  }
 	  my $rt_data = {
 		'state' => $tr_res->{'paused'} ? 0 : 1,
 		#'complete' => defined $tr_res->{'progress'}{'have'} ? 1 :0,
@@ -668,7 +673,7 @@ sub t2r {
 		'state_changed' => $tr_res->{'activity-date'},
 		'total_uploaded' => $tr_res->{'uploaded'},
 		'total_downloaded' => $tr_res->{'downloaded'},
-		'custom1' => 'transmission',
+		'custom1' => join( ',', @tags ),
 		'hashing' => 0,
   	  };
 


### PR DESCRIPTION
The title basically. I recently did a --t2r and had to manually sync all the tags after the fact (flood as UI for both). I also capitalize my labels, so `'Transmission'` not `'transmission'`, so a override for that.

This would 
* make copying lables that part of the t2r functionality
* allow overriding 'transmission' label
  * Override with any or multiple (comma separated) label(s)
  * or disable the extra label by setting the env to empty like `export TRANSMISSION_TAG=`