### PR TITLE
Convert added time to a string so rtorrent actually reports it

### DIFF
--- a/rfr.pl
+++ b/rfr.pl
@@ -663,7 +663,7 @@ sub t2r {
 	  my $rt_data = {
 		'state' => $tr_res->{'paused'} ? 0 : 1,
 		#'complete' => defined $tr_res->{'progress'}{'have'} ? 1 :0,
-		'custom' => {'addtime' => $tr_res->{'added-date'} },
+		'custom' => {'addtime' => sprintf( "%d", $tr_res->{'added-date'} ) },
 		'timestamp.finished' => $tr_res->{'done-date'},
 		'state_changed' => $tr_res->{'activity-date'},
 		'total_uploaded' => $tr_res->{'uploaded'},


### PR DESCRIPTION
Bugfix. Not sure why, but rtorrent api eats `addtime` when it's an integer, while it displays it correctly when it's stored as a string. Doesn't help that the rbedit displays both the same (unquoted). Might be fixed in later rtorrent versions, but flood is pinned to .986 or something like that that's a bit older, so fixing for older rtorrent versions.

numeric xmlrpc:

![image](https://github.com/user-attachments/assets/6588e607-e2c3-4036-84be-e7a34ac1ffb3)

string bencode/quoted xmlrpc:

![image](https://github.com/user-attachments/assets/89f389e5-5614-4cf9-b60c-b61ed48c6eb0)


For anyone else that might find this and wants to bulk update their addtime to strings:
```
cd rtorrent/.session/
# --string does the string conversion
for f in *.torrent.rtorrent; do echo rbe put --inplace --input $f custom addtime --string `rbe get --input $f custom addtime`; done
```